### PR TITLE
FEAT: /archiving/[courseId] 페이지 서버사이드 렌더링으로 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
+/Todo.md
 /node_modules
 /.pnp
 .pnp.js

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,11 @@
  */
 
 const nextConfig = {
+  // logging: {
+  //   fetches: {
+  //     fullUrl: true,
+  //   },
+  // },
   // add drive.google.com to remotePatterns
   images: {
     remotePatterns: [

--- a/src/api/fetch.ts
+++ b/src/api/fetch.ts
@@ -55,6 +55,11 @@ export async function fetchCourseInfo(courseId: number) {
     }/values/CourseInfoSheet!${courseId + 1}:${courseId + 1}?key=${
       process.env.NEXT_PUBLIC_GOOGLE_API_KEY
     }`,
+    {
+      next: {
+        revalidate: 60,
+      },
+    },
   );
   const json = await response.json();
   const values = await json.values[0];
@@ -85,6 +90,11 @@ export async function fetchAssignments(courseId: number, courseName: string) {
   // Sheet 'AssignmentsSheet' is holding infos about assignments
   const response = await fetch(
     `https://sheets.googleapis.com/v4/spreadsheets/${process.env.NEXT_PUBLIC_GOOGLE_SHEET_ID}/values/AssignmentsSheet?key=${process.env.NEXT_PUBLIC_GOOGLE_API_KEY}`,
+    {
+      next: {
+        revalidate: 60,
+      },
+    },
   );
   const json = await response.json();
   const values = await json.values;

--- a/src/app/archiving/[courseId]/ArchivingCourse.tsx
+++ b/src/app/archiving/[courseId]/ArchivingCourse.tsx
@@ -12,77 +12,27 @@ import {
   AssignmentType,
 } from "@/api/fetch";
 import { courses } from "@/api/courses";
-import AssignmentsContainer from "@/components/AssignmentsContainer/AssignmentsContainer";
-import Layout from "@/components/Layout/Layout";
-import SemesterSelect from "@/components/SemesterSelect/SemesterSelect";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import SemesterSelect from "@/components/SemesterSelect/SemesterSelect";
+import AssignmentsContainer from "@/components/AssignmentsContainer/AssignmentsContainer";
 
 export default function ArchivingCourse({
-  params,
+  courseInfo,
+  assignments,
 }: {
-  params: { courseId: string };
+  courseInfo: CourseInfoType;
+  assignments: AssignmentType[];
 }) {
-  // router const
   const router = useRouter();
 
-  // extract semesters from courses
   const semesters = Object.keys(courses).slice(1);
 
-  // extract courseId from slug
-  const courseId: number = parseInt(params.courseId);
-
-  // a semester selected by SemesterSelect
   const [selectedSemester, setSelectedSemester] = useState<string>("entire");
-  // courseInfo
-  const [courseInfo, setCourseInfo] = useState<CourseInfoType>({
-    courseId: 0,
-    track: "",
-    name: "",
-    professors: [],
-  });
-  // assignments
-  const [assignments, setAssignments] = useState<AssignmentType[]>([]);
-
-  // fetch courseInfo by using fetchCourseInfo function
-  useEffect(() => {
-    const fetchData = async () => {
-      const fetchedCourseInfo = await fetchCourseInfo(courseId);
-      setCourseInfo(fetchedCourseInfo);
-    };
-
-    fetchData();
-  }, [courseId]);
-
-  // fetch assignments by using fetchAssignments function
-  useEffect(() => {
-    const fetchData = async () => {
-      if (courseInfo.courseId != 0) {
-        const fetchedAssignments = await fetchAssignments(
-          courseInfo.courseId,
-          courseInfo.name,
-        );
-        setAssignments(fetchedAssignments);
-      }
-    };
-
-    fetchData();
-  }, [courseInfo]);
-
-  // if courseInfo is not loaded, return LOADING
-  if (courseInfo.courseId === 0) {
-    return (
-      <Layout>
-        <h2>LOADING...</h2>
-      </Layout>
-    );
-  }
 
   return (
-    <Layout>
-      {/* h1: COURSE */}
-      <h1>C0URSE</h1>
+    <>
       {/* SemesterSelect: filter semesters */}
       <div className="border-t-2 border-solid border-black">
         <SemesterSelect
@@ -111,7 +61,6 @@ export default function ArchivingCourse({
           onClick={() => router.back()}
         />
       </div>
-
       {/* div: a container for assignments */}
       <div className="border-t-2 border-solid border-black p-8 font-Pretendard md:p-10">
         {semesters
@@ -149,6 +98,6 @@ export default function ArchivingCourse({
             }
           })}
       </div>
-    </Layout>
+    </>
   );
 }

--- a/src/app/archiving/[courseId]/ArchivingCourse.tsx
+++ b/src/app/archiving/[courseId]/ArchivingCourse.tsx
@@ -5,12 +5,7 @@ archiving/[courseId]/ArchivingCourse.tsx:
 
 "use client";
 
-import {
-  CourseInfoType,
-  fetchCourseInfo,
-  fetchAssignments,
-  AssignmentType,
-} from "@/api/fetch";
+import { CourseInfoType, AssignmentType } from "@/api/fetch";
 import { courses } from "@/api/courses";
 import Image from "next/image";
 import { useRouter } from "next/navigation";

--- a/src/app/archiving/[courseId]/error.tsx
+++ b/src/app/archiving/[courseId]/error.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import Layout from "@/components/Layout/Layout";
+
+export default function Page() {
+  return (
+    <Layout>
+      <h2>과목 정보를 불러오는 중 에러가 발생했습니다...</h2>
+    </Layout>
+  );
+}

--- a/src/app/archiving/[courseId]/page.tsx
+++ b/src/app/archiving/[courseId]/page.tsx
@@ -3,9 +3,37 @@ archiving/[courseId]/page.tsx:
   A server-side page for each course in /archiving
 */
 
+import { fetchAssignments, fetchCourseInfo } from "@/api/fetch";
 import ArchivingCourse from "./ArchivingCourse";
+import Layout from "@/components/Layout/Layout";
 
-export default function Page({ params }: { params: { courseId: string } }) {
+export default async function Page({
+  params,
+}: {
+  params: { courseId: string };
+}) {
   const { courseId } = params;
-  return <ArchivingCourse params={{ courseId: courseId }} />;
+
+  const courseInfo = await fetchCourseInfo(parseInt(courseId));
+
+  if (!courseInfo) {
+    return (
+      <Layout>
+        <h2>LOADING...</h2>
+      </Layout>
+    );
+  }
+
+  const assignments = await fetchAssignments(
+    courseInfo.courseId,
+    courseInfo.name,
+  );
+
+  return (
+    <Layout>
+      {/* h1: COURSE */}
+      <h1>C0URSE</h1>
+      <ArchivingCourse courseInfo={courseInfo} assignments={assignments} />
+    </Layout>
+  );
 }


### PR DESCRIPTION
- 기존에 클라이언트에서 받아오던 과목, 과제 관련 정보를 서버에서 캐시하고 렌더링하도록 변경했습니다.

- 과목, 과제 정보 불러올때 캐시를 적용해서 현재는 1분 이후에 다시 새로운 데이터를 불러오도록 되어있습니다.
이에 따라서 과목 정보 업데이트 이후에도 최대 1분간 stale한 데이터가 보일 수 있습니다.
데이터 캐시 시간을 어느정도로 할 것인지 관련해서는 추후에 더 논의해보면 좋을것같습니다.

- 서버 사이드 렌더링을 위한 error Boundary를 추가했습니다. (error.tsx)