### PR TITLE
feat: Create rendering for no assignments

### DIFF
--- a/src/app/archiving/[courseId]/ArchivingCourse.tsx
+++ b/src/app/archiving/[courseId]/ArchivingCourse.tsx
@@ -79,6 +79,25 @@ export default function ArchivingCourse({
     );
   }
 
+  // 학기별 과제물을 렌더링하는 함수(템플릿)
+  const renderSemesterInfo = (
+    semester: string,
+    filteredAssignments: AssignmentType[],
+  ) => {
+    const [year, term] = semester.split("-");
+    return (
+      <div key={semester} className="mb-10">
+        <h2 className="mx-0 mb-2">{`${year}학년도 ${term}학기`}</h2>
+        <p>{`지도교수 | ${courseInfo.professors[semester]}`}</p>
+        {filteredAssignments.length > 0 ? (
+          <AssignmentsContainer assignments={filteredAssignments} />
+        ) : (
+          <p className="mt-5 font-bold">업로드된 과제물이 없습니다.</p>
+        )}
+      </div>
+    );
+  };
+
   return (
     <Layout>
       {/* h1: COURSE */}
@@ -116,36 +135,27 @@ export default function ArchivingCourse({
       <div className="border-t-2 border-solid border-black p-8 font-Pretendard md:p-10">
         {semesters
           .filter((semester) => {
-            // filter semesters according to selectedSemester
-            if (selectedSemester != "entire") {
-              return semester === selectedSemester;
-            } else {
-              return true;
-            }
+            return (
+              selectedSemester === "entire" || semester === selectedSemester
+            );
           })
           .map((semester) => {
-            if (semester != "entire") {
-              // filter assignments by semesters
-              const filteredAssignments = assignments.filter(
-                (assignment) =>
-                  `${assignment.year}-${assignment.semester}` === semester,
-              );
+            const filteredAssignments = assignments.filter(
+              (assignment) =>
+                `${assignment.year}-${assignment.semester}` === semester,
+            );
 
-              if (courseInfo.professors[semester] != "") {
-                return (
-                  /* div: a container for assignments in each semester */
-                  <div key={semester} className="mb-10">
-                    {/* h2: semester */}
-                    <h2 className="mx-0 mb-2">{`${
-                      semester.split("-")[0]
-                    }학년도 ${semester.split("-")[1]}학기`}</h2>
-                    {/* p: professor */}
-                    <p>{`지도교수 | ${courseInfo.professors[semester]}`}</p>
-                    {/* AssignmentsContainer */}
-                    <AssignmentsContainer assignments={filteredAssignments} />
-                  </div>
-                );
-              }
+            if (courseInfo.professors[semester]) {
+              return renderSemesterInfo(semester, filteredAssignments);
+            } else if (selectedSemester !== "entire") {
+              // '전체 학기'가 아닐 때, 강좌가 열리지 않은 학기를 나타내기 위한 렌더링
+              return (
+                <div key={semester}>
+                  <p className="text-lg font-bold">
+                    해당 학기에 강좌가 열리지 않았습니다.
+                  </p>
+                </div>
+              );
             }
           })}
       </div>


### PR DESCRIPTION
# 작업내용
- 아카이빙된 과제물을 필터링할 때, 과제물이 없을 경우 조건에 따라 적절한 텍스트 UI를 반영했습니다.
  - 해당 학기에 강좌는 열렸으나 과제물이 없는 경우, '업로드된 과제물이 없습니다'로 표시됩니다.
  - 해당 학기에 강좌가 열리지 않은 경우, '해당 학기에 강좌가 열리지 않았습니다'로 표시됩니다. ('전체 학기' 검색 시에는 원래 웹사이트와 같이 표시되지 않게 설정하였습니다.)

- 그 외 코드 더 간결하게 정리할 수 있는 부분들 리팩토링 진행했습니다.