### PR TITLE
feat: Update 'SemesterSelect' Dropdown Component

### DIFF
--- a/src/components/SemesterSelect/SemesterSelect.tsx
+++ b/src/components/SemesterSelect/SemesterSelect.tsx
@@ -15,51 +15,55 @@ export default function SemesterSelect({
   onSelectionChange?: (value: string) => void;
 }) {
   // selectedSemester: value of the select box
-  const [selectedSemester, setSelectedSemester] = useState("0");
+  const [semesterIndex, setSemesterIndex] = useState<number>(0);
   // isFocused: true when the select box is focused
   const [isFocused, setIsFocused] = useState(false);
 
-  // handler for onChange event on select
-  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newValue = e.target.value;
-    setSelectedSemester(newValue);
-    setIsFocused(false);
-    onSelectionChange?.(newValue); // send newValue to onSelectionChange function
-  };
-
-  const semesters: string[] = Object.keys(courses);
+  const semesters: string[] = Object.keys(courses); // ["entire", "2023-2", "2023-1", ...]
+  const parsedSemesters: string[] = semesters.map(
+    (
+      semester,
+      index, // ["전체 학기", "2023-2", "2023-1", ...]
+    ) => (index === 0 ? "전체 학기" : semester),
+  );
 
   return (
-    <div className="flex flex-row items-center font-Pretendard text-2xl font-extrabold md:text-3xl">
-      <div className="border-r-2 border-solid border-black">
-        <select
-          className="cursor-pointer appearance-none border-r-2 border-solid border-black px-16"
-          onFocus={() => setIsFocused(true)} // true when focused
-          onChange={handleChange} // handleChange when changed
-          onBlur={() => setIsFocused(false)} // false when blurred
-          value={selectedSemester}
+    <div className="relative flex h-9 select-none items-center font-Pretendard text-2xl font-extrabold md:text-3xl">
+      <div
+        className="w-56 cursor-pointer appearance-none border-r-2 border-solid border-black text-center"
+        onClick={() => {
+          setIsFocused(!isFocused);
+        }}
+      >
+        <p>{parsedSemesters[semesterIndex]}</p>
+      </div>
+      {isFocused && (
+        <div
+          className="appearnce-none absolute left-0 cursor-pointer bg-white"
+          style={{ top: "38px" }}
         >
-          {semesters.map((value) => {
-            {
-              /* value: entire, 2023-2, 2023-1, ... */
-            }
-            {
-              /* option: 전체 학기, 2023-2, 2023-1, ... */
-            }
-            // basically, option equals to value
-            let option = value;
-            if (option === "entire") {
-              // if option equals to "entire", change option to "전체 학기"
-              option = "전체 학기";
-            }
-            return (
-              <option value={value} key={value}>
-                {option}
-              </option>
-            );
-          })}
-        </select>
-        <span className="px-3 text-lg">{isFocused ? "▲" : "▼"}</span>
+          {parsedSemesters.map((semester, index) => (
+            <div
+              className="w-56 border-b-2 border-r-2 border-solid border-black text-center hover:bg-black hover:text-white"
+              key={index}
+              onClick={() => {
+                setSemesterIndex(index);
+                setIsFocused(false);
+                onSelectionChange?.(semesters[index]);
+              }}
+            >
+              {semester}
+            </div>
+          ))}
+        </div>
+      )}
+      <div
+        className="flex h-full cursor-pointer appearance-none items-center justify-center border-r-2 border-solid border-black px-3 text-lg"
+        onClick={() => {
+          setIsFocused(!isFocused);
+        }}
+      >
+        {isFocused ? "▲" : "▼"}
       </div>
     </div>
   );


### PR DESCRIPTION
# 작업내용
- 기존의 `<select>` 및 `<option>` 태그로 이루어진 드롭다운 UI는 커스터마이징에 한계가 있어, 직접 드롭다운 UI 제작하고 현재 웹사이트에 맞는 디자인 적용했습니다. 또한 화살표 버튼을 눌렀을 때도 드롭다운이 작동하게끔 수정했습니다.
- 이에 따라 `onChange` 이벤트 담당하던 로직도 불필요하다고 생각해 삭제했습니다.
- 드롭다운 옵션을 표시하기 위해 `semesters`를 `map`하는 코드에서, 학기 데이터를 파싱하는 부분을 따로 `const`로 빼서 작성했습니다.
