### PR TITLE
FEAT: 홈페이지 보러가기 -> /archiving 특정 학기로 이동 기능 추가

### DIFF
--- a/src/api/courses.ts
+++ b/src/api/courses.ts
@@ -9,6 +9,7 @@ api/courses.ts:
 The things that must be updated manually every semester:
   Coursestype,
   courses
+  SemesterName
 */
 
 export const getSemesterName = (semester: CoursesKey) => {

--- a/src/api/courses.ts
+++ b/src/api/courses.ts
@@ -11,9 +11,24 @@ The things that must be updated manually every semester:
   courses
 */
 
+export const getSemesterName = (semester: CoursesKey) => {
+  return SemesterName[semester];
+};
+
+// 각 학기 이름을 자유롭게 설정할 수 있는 enum 역할을 수행.
+// SemesterName key should be the same as CoursesKey
+const SemesterName: Record<CoursesKey, string> = {
+  entire: "전체 학기" as const,
+  "2023-2": "2023-2" as const,
+  "2023-1": "2023-1" as const,
+  "2022-2": "2022-2" as const,
+  "2022-1": "2022-1" as const,
+};
+
+export type CoursesKey = keyof CoursesType;
+
 // CoursesType: a type for 'courses'
 export type CoursesType = {
-  [index: string]: TrackType;
   entire: TrackType;
   "2023-2": TrackType;
   "2023-1": TrackType;

--- a/src/app/archiving/[courseId]/ArchivingCourse.tsx
+++ b/src/app/archiving/[courseId]/ArchivingCourse.tsx
@@ -6,7 +6,7 @@ archiving/[courseId]/ArchivingCourse.tsx:
 "use client";
 
 import { CourseInfoType, AssignmentType } from "@/api/fetch";
-import { courses } from "@/api/courses";
+import { CoursesKey, courses } from "@/api/courses";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -16,15 +16,18 @@ import AssignmentsContainer from "@/components/AssignmentsContainer/AssignmentsC
 export default function ArchivingCourse({
   courseInfo,
   assignments,
+  initialSemester,
 }: {
   courseInfo: CourseInfoType;
   assignments: AssignmentType[];
+  initialSemester: CoursesKey;
 }) {
   const router = useRouter();
 
   const semesters = Object.keys(courses).slice(1);
 
-  const [selectedSemester, setSelectedSemester] = useState<string>("entire");
+  const [selectedSemester, setSelectedSemester] =
+    useState<CoursesKey>(initialSemester);
 
   // 학기별 과제물을 렌더링하는 함수(템플릿)
   const renderSemesterInfo = (
@@ -50,6 +53,7 @@ export default function ArchivingCourse({
       {/* SemesterSelect: filter semesters */}
       <div className="border-t-2 border-solid border-black">
         <SemesterSelect
+          selectedSemester={selectedSemester}
           onSelectionChange={(value) => setSelectedSemester(value)}
         />
       </div>

--- a/src/app/archiving/[courseId]/page.tsx
+++ b/src/app/archiving/[courseId]/page.tsx
@@ -6,11 +6,17 @@ archiving/[courseId]/page.tsx:
 import { fetchAssignments, fetchCourseInfo } from "@/api/fetch";
 import ArchivingCourse from "./ArchivingCourse";
 import Layout from "@/components/Layout/Layout";
+import keyValidator from "@/utils/keyValidator";
+import { courses } from "@/api/courses";
 
 export default async function Page({
   params,
+  searchParams,
 }: {
   params: { courseId: string };
+  searchParams: {
+    semester: string;
+  };
 }) {
   const { courseId } = params;
 
@@ -29,11 +35,19 @@ export default async function Page({
     courseInfo.name,
   );
 
+  const semesterQuery = searchParams.semester;
+
+  const semester = keyValidator(semesterQuery, courses, "entire");
+
   return (
     <Layout>
       {/* h1: COURSE */}
       <h1>C0URSE</h1>
-      <ArchivingCourse courseInfo={courseInfo} assignments={assignments} />
+      <ArchivingCourse
+        courseInfo={courseInfo}
+        assignments={assignments}
+        initialSemester={semester}
+      />
     </Layout>
   );
 }

--- a/src/app/archiving/page.tsx
+++ b/src/app/archiving/page.tsx
@@ -8,15 +8,28 @@ archiving/page.tsx:
 
 import Layout from "@/components/Layout/Layout";
 import SemesterSelect from "@/components/SemesterSelect/SemesterSelect";
-import { courses, TrackType } from "../../api/courses";
-import { useState } from "react";
+import { courses, CoursesKey, CoursesType } from "../../api/courses";
+import { useEffect, useState } from "react";
 import CoursesContainer from "@/components/CoursesContainer/CoursesContainer";
+import { useRouter, useSearchParams } from "next/navigation";
+import hasKeyinObj from "@/utils/hasKeyinObj";
 
 export default function Archiving() {
-  const [selectedSemester, setSelectedSemester] = useState<string>("entire");
-  const [selectedCourses, setSelectedCourses] = useState<TrackType>(
-    courses["entire"],
+  const params = useSearchParams();
+  const router = useRouter();
+
+  const semesterQuery = params.get("semester");
+
+  const [selectedSemester, setSelectedSemester] = useState<CoursesKey>(
+    // if semesterQuery is in courses, return semesterQuery. else return "entire"
+    hasKeyinObj(semesterQuery, courses, "entire"),
   );
+
+  const selectedCourses = courses[selectedSemester];
+
+  useEffect(() => {
+    router.replace(`/archiving?semester=${selectedSemester}`);
+  }, [selectedSemester]);
 
   return (
     <Layout>
@@ -25,10 +38,10 @@ export default function Archiving() {
       {/* SemesterSelect: dropdown select box */}
       <div className="border-t-2 border-solid border-black">
         <SemesterSelect
+          selectedSemester={selectedSemester}
           /* set selectedSemester and selectedCourses to the changed value */
           onSelectionChange={(value) => {
             setSelectedSemester(value);
-            setSelectedCourses(courses[value]);
           }}
         />
       </div>

--- a/src/app/archiving/page.tsx
+++ b/src/app/archiving/page.tsx
@@ -12,7 +12,7 @@ import { courses, CoursesKey, CoursesType } from "../../api/courses";
 import { useEffect, useState } from "react";
 import CoursesContainer from "@/components/CoursesContainer/CoursesContainer";
 import { useRouter, useSearchParams } from "next/navigation";
-import hasKeyinObj from "@/utils/hasKeyinObj";
+import keyValidator from "@/utils/keyValidator";
 
 export default function Archiving() {
   const params = useSearchParams();
@@ -22,7 +22,7 @@ export default function Archiving() {
 
   const [selectedSemester, setSelectedSemester] = useState<CoursesKey>(
     // if semesterQuery is in courses, return semesterQuery. else return "entire"
-    hasKeyinObj(semesterQuery, courses, "entire"),
+    keyValidator(semesterQuery, courses, "entire"),
   );
 
   const selectedCourses = courses[selectedSemester];

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,10 +10,31 @@ import { useEffect, useRef, useState, useCallback } from "react";
 import useEmblaCarousel from "embla-carousel-react";
 import "./progressbar.css";
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/solid";
+import { courses } from "@/api/courses";
 const TWEEN_FACTOR = 3;
 
 const numberWithinRange = (number: number, min: number, max: number) =>
   Math.min(Math.max(number, min), max);
+
+const renderSlideLink = (semester: string, snsLink: string) => {
+  const link = `/archiving?semester=${semester}`;
+
+  return semester in courses ? (
+    <Link href={link} rel="noopener noreferrer">
+      <button className="relative mx-auto mt-3 block h-10 overflow-hidden border border-[#FF5C00] text-[#FF5C00] transition-all duration-200 before:absolute before:bottom-0 before:left-0 before:right-0 before:top-0 before:m-auto before:h-0 before:w-0 before:rounded-sm before:bg-[#FF5C00] before:duration-300 before:ease-out hover:text-white hover:before:h-40 hover:before:w-[100%] hover:before:opacity-80">
+        <span className="relative z-10 px-4 py-1 font-MonoplexWideNerd font-semibold">
+          보러가기
+        </span>
+      </button>
+    </Link>
+  ) : (
+    <Link href={snsLink} target="_blank" rel="noopener noreferrer">
+      <div className="relative mx-auto mt-3 block h-10 w-10 overflow-hidden">
+        <Image src="/assets/img/instagram.png" fill alt="instagram" />
+      </div>
+    </Link>
+  );
+};
 
 export default function Main() {
   const [emblaRef, embla] = useEmblaCarousel({ loop: true });
@@ -157,6 +178,7 @@ export default function Main() {
       url: "/assets/img/poster/poster13_2.png",
     },
   ];
+
   const handlePrevious = () => {
     embla?.scrollPrev();
   };
@@ -281,17 +303,7 @@ export default function Main() {
                   <div className="mt-4 text-center">
                     <h4>{slide.date}</h4>
                   </div>
-                  <Link
-                    href={slide.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <button className="relative mx-auto mt-3 block h-10 overflow-hidden border border-[#FF5C00] text-[#FF5C00] transition-all duration-200 before:absolute before:bottom-0 before:left-0 before:right-0 before:top-0 before:m-auto before:h-0 before:w-0 before:rounded-sm before:bg-[#FF5C00] before:duration-300 before:ease-out hover:text-white hover:before:h-40 hover:before:w-[100%] hover:before:opacity-80">
-                      <span className="relative z-10 px-4 py-1 font-MonoplexWideNerd font-semibold">
-                        보러가기
-                      </span>
-                    </button>
-                  </Link>
+                  {renderSlideLink(slide.semester, slide.link)}
                 </div>
               ))}
             </div>

--- a/src/components/CoursesContainer/CoursesContainer.tsx
+++ b/src/components/CoursesContainer/CoursesContainer.tsx
@@ -3,12 +3,26 @@ CoursesContainer.tsx:
   A container that contains CourseButtons
 */
 
-import { CourseType } from "@/api/courses";
+import { CourseType, courses } from "@/api/courses";
+import keyValidator from "@/utils/keyValidator";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 
 function CourseButton({ course }: { course: CourseType }) {
+  const query = useSearchParams();
+
+  const semester = query.get("semester");
+
+  const href = semester
+    ? `/archiving/${course.courseId}?semester=${keyValidator(
+        semester,
+        courses,
+        "entire",
+      )}`
+    : `/archiving/${course.courseId}`;
+
   return (
-    <Link href={`/archiving/${course.courseId}`}>
+    <Link href={href}>
       <button className="my-2 mr-2 rounded-3xl border border-solid border-black px-6 py-2 font-Pretendard text-sm hover:border-[#FF5C00] hover:bg-[#FF5C00] hover:text-white md:text-base">
         {course.name}
       </button>

--- a/src/components/SemesterSelect/SemesterSelect.tsx
+++ b/src/components/SemesterSelect/SemesterSelect.tsx
@@ -1,19 +1,23 @@
 import { useState, useRef, useEffect } from "react";
-import { courses } from "@/api/courses";
+import { CoursesKey, courses, getSemesterName } from "@/api/courses";
 
 export default function SemesterSelect({
   onSelectionChange,
+  selectedSemester,
 }: {
-  onSelectionChange?: (value: string) => void;
+  selectedSemester: CoursesKey;
+  onSelectionChange: (value: CoursesKey) => void;
 }) {
-  const [semesterIndex, setSemesterIndex] = useState<number>(0);
   const [isFocused, setIsFocused] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
-  const semesters: string[] = Object.keys(courses); // ["entire", "2023-2", "2023-1", ...]
-  const parsedSemesters: string[] = semesters.map((semester, index) =>
-    index === 0 ? "전체 학기" : semester,
-  );
+  // ["entire", "2023-2", "2023-1", ...]
+  const semesters = Object.keys(courses) as Array<CoursesKey>;
+
+  // semester를 받아서 해당하는 학기 이름을 반환하는 함수
+  // entire를 전체학기 로 변환하기 위해 getSemesterName 함수를 사용했습니다.
+  const renderSemesterName = (semester: CoursesKey) =>
+    getSemesterName(semester);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -40,24 +44,23 @@ export default function SemesterSelect({
           setIsFocused(!isFocused);
         }}
       >
-        <p>{parsedSemesters[semesterIndex]}</p>
+        <p>{renderSemesterName(selectedSemester)}</p>
       </div>
       {isFocused && (
         <div
           className="appearnce-none absolute left-0 cursor-pointer bg-white"
           style={{ top: "38px", zIndex: 9999 }}
         >
-          {parsedSemesters.map((semester, index) => (
+          {semesters.map((semester, index) => (
             <div
               className="w-56 border-b-2 border-r-2 border-solid border-black text-center hover:bg-black hover:text-white"
               key={index}
               onClick={() => {
-                setSemesterIndex(index);
                 setIsFocused(false);
-                onSelectionChange?.(semesters[index]);
+                onSelectionChange(semesters[index]);
               }}
             >
-              {semester}
+              {renderSemesterName(semester)}
             </div>
           ))}
         </div>

--- a/src/utils/hasKeyinObj.ts
+++ b/src/utils/hasKeyinObj.ts
@@ -1,0 +1,10 @@
+// check if the key is in the object else return the default key
+const hasKeyinObj = <T>(
+  key: string | null,
+  checkObj: T extends Object ? T : never,
+  defaultKey: keyof T,
+): keyof T => {
+  return key && key in checkObj ? (key as keyof T) : defaultKey;
+};
+
+export default hasKeyinObj;

--- a/src/utils/keyValidator.ts
+++ b/src/utils/keyValidator.ts
@@ -1,5 +1,5 @@
 // check if the key is in the object else return the default key
-const hasKeyinObj = <T>(
+const keyValidator = <T>(
   key: string | null,
   checkObj: T extends Object ? T : never,
   defaultKey: keyof T,
@@ -7,4 +7,4 @@ const hasKeyinObj = <T>(
   return key && key in checkObj ? (key as keyof T) : defaultKey;
 };
 
-export default hasKeyinObj;
+export default keyValidator;


### PR DESCRIPTION
- 홈페이지에서는 courses에 해당 학기가 있는 경우 보러 가기 버튼을, 없는 경우 인스타 아이콘을 렌더링하도록 수정했습니다.
  인스타 아이콘은 About 페이지에 있는 아이콘을 재사용했는데 괜찮은지 확인부탁드립니다.
  <img width="434" alt="스크린샷 2024-06-12 오후 2 20 19" src="https://github.com/isc-exhibition/ischive/assets/81099627/ca54f8b2-a5b8-4aa2-9302-bf04a01f8ac8">

- /archiving 페이지와 /archiving/[courseId] 페이지에 semester query param을 받도록해서,
  만약 해당하는 semester가 있는 경우 해당 semester로 state를 설정하고,
  만약 잘못된 param이나 학기를 넣는 경우에는 전체학기로 바뀌도록 수정했습니다.

- 학기 이름의 enum 역할을 하는 객체를 courses.ts에 만들고,
학기명이 필요한 경우에 getSemesterName 함수를 통해 값을 얻을 수 있도록 추가했습니다. ( eg. entire -> "전체 학기" 로 )